### PR TITLE
Feat: vote 페이지 전반 UI를 Figma 시안에 맞춰 수정

### DIFF
--- a/src/components/vote/index.jsx
+++ b/src/components/vote/index.jsx
@@ -3,15 +3,15 @@ import VoteHeader from './voteComponents/VoteHeader';
 import CandidateCard from './voteComponents/CandidateCard';
 import VoteButton from './voteComponents/VoteButton';
 import CancelButton from './voteComponents/CancelButton';
-
 import Disclaimer from './voteComponents/Disclaimer';
-import useVote from './useVote';
-
-import toast from 'react-hot-toast';
 import RegionSelect from './voteComponents/RegionSelect';
+
+import useVote from './useVote';
+import toast from 'react-hot-toast';
 
 import { sendVote, cancelVote } from '@/apis/voteApi';
 import { candidates } from '@/utils/candidates';
+import { getVotedCandidate, saveVotedCandidate } from '@/utils/localStorage';
 
 const Vote = () => {
   const [selectedRegionId, setSelectedRegionId] = useState(null);
@@ -22,16 +22,18 @@ const Vote = () => {
     setSelectedRegionId(regionId);
   };
 
-  // 지역 먼저 선택하라는 토스트
+  // 투표 처리
   const handleVote = async () => {
-    if (localStorage.getItem('voteInfo')) {
+    if (getVotedCandidate()) {
       toast.error('이미 투표를 완료하셨습니다.');
       return;
     }
+
     if (selectedRegionId === null) {
       toast.error('지역을 먼저 선택해주세요.');
       return;
     }
+
     const selectedCandidate = candidates.find((candidate) => candidate.id === selected);
     if (!selectedCandidate) {
       toast.error('후보를 선택해주세요.');
@@ -44,10 +46,7 @@ const Vote = () => {
         candidate: selectedCandidate.id,
       });
 
-      localStorage.setItem(
-        'voteInfo',
-        JSON.stringify({ region: selectedRegionId, candidate: selectedCandidate.id })
-      );
+      saveVotedCandidate(selectedCandidate.id, selectedRegionId);
       setIsVoted(true);
       toast.success(`${selectedCandidate.name} 후보에게 투표 완료되었습니다.`);
     } catch (err) {
@@ -56,8 +55,10 @@ const Vote = () => {
     }
   };
 
+  // 투표 취소 처리
   const handleCancelVote = async () => {
     const selectedCandidate = candidates.find((candidate) => candidate.id === selected);
+
     try {
       await cancelVote({
         region: selectedRegionId,
@@ -75,10 +76,12 @@ const Vote = () => {
     }
   };
 
+  // 초기 로딩 시 로컬 스토리지에서 투표 정보 복원
   useEffect(() => {
-    const stored = localStorage.getItem('voteInfo'); // 로컬에서 데이터 가져옴
-    if (stored) {
-      const { regionId, candidateId } = JSON.parse(stored);
+    const candidateId = getVotedCandidate();
+    if (candidateId) {
+      const stored = localStorage.getItem('voteInfo'); // regionId는 직접 파싱
+      const { regionId } = JSON.parse(stored);
       setSelectedRegionId(regionId);
       selectCandidate(candidateId);
       setIsVoted(true);
@@ -86,12 +89,11 @@ const Vote = () => {
   }, []);
 
   return (
-    <div className="mx-auto max-w-md space-y-4 p-4">
+    <div className="mx-auto max-w-md md:max-w-2xl space-y-4 p-4">
       <VoteHeader />
-      {/* 지역선택 */}
+
       <RegionSelect selectedRegionId={selectedRegionId} onRegionSelect={handleRegionSelect} />
 
-      {/* 후보자 카드 */}
       {candidates.map((candidate) => (
         <CandidateCard
           key={candidate.id}
@@ -104,7 +106,6 @@ const Vote = () => {
         />
       ))}
 
-      {/* 투표 */}
       {isVoted ? (
         <CancelButton onClick={handleCancelVote} />
       ) : (

--- a/src/components/vote/voteComponents/CandidateCard.jsx
+++ b/src/components/vote/voteComponents/CandidateCard.jsx
@@ -5,20 +5,20 @@ import unvoted from '../images/unvoted.png';
 const CandidateCard = ({ image, name, party, slogan, selected, onClick }) => {
   return (
     <div
-      className="mx-auto flex w-full max-w-[95%] items-center justify-between gap-4 rounded-2xl border-3 px-4 py-2 md:max-w-md"
+      className="mx-auto flex w-full max-w-full items-center justify-between gap-4 rounded-2xl border-3 px-3 py-2 md:max-w-[700px]  md:gap-6 md:rounded-2xl md:border-4 md:px-6 md:py-3"
       onClick={onClick}
     >
       {/* 후보 이미지 */}
-      <img src={image} alt={name} className="h-10 w-10 rounded-full object-cover" />
+      <img src={image} alt={name} className="h-12 w-12 md:h-14 md:w-14 rounded-full object-cover" />
       {/* 이름, 정당, 슬로건 */}
       <div className="flex-1">
-        <p className="text-sm font-bold text-gray-800">
-          {name} <span className="text-xs text-gray-500">{party}</span>
+        <p className="text-base md:text-xl font-bold text-gray-800">
+          {name} <span className="text-sm md:text-lg text-gray-500">{party}</span>
         </p>
-        <p className="text-sm text-gray-700">“{slogan}”</p>
+        <p className="text-sm md:text-2xl text-gray-700">“{slogan}”</p>
       </div>
       {/* 선택 상태 아이콘 */}
-      <img src={selected ? voted : unvoted} alt="투표 상태" className="h-10 w-10" />
+      <img src={selected ? voted : unvoted} alt="투표 상태" className="h-8 w-8 md:h-12 md:w-12" />
     </div>
   );
 };

--- a/src/components/vote/voteComponents/Disclaimer.jsx
+++ b/src/components/vote/voteComponents/Disclaimer.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 
 const Disclaimer = () => {
   return (
-    <div className="mt-6 flex w-full justify-center px-4">
-      <div className="max-w-md text-center text-xs leading-relaxed text-gray-400">
-        <p className="break-words">※ 실제 선거와 무관한 모의 체험 콘텐츠입니다.</p>
-        <p className="mt-1 break-words">
-          후보 이름, 결과 등은 단순한 사용자 선택 데이터이며,
-          <br className="block sm:hidden" />
-          공식 지지율이나 선거 결과와는 관련이 없습니다.
-        </p>
-      </div>
+    <div className="mt-6 w-full px-4 text-center text-gray-400">
+      <p className="text-sm leading-relaxed">
+        ※ 본 페이지는 실제 선거와 무관한 모의 체험 콘텐츠입니다.
+      </p>
+      <p className="text-sm leading-relaxed md:whitespace-nowrap">
+        모든 데이터는 사용자 참여 기반의 체험용으로 수집되며,
+        <br className="md:hidden" />
+        공식 지지율이나 선거 결과와는 관련이 없습니다.
+      </p>
     </div>
   );
 };

--- a/src/components/vote/voteComponents/RegionSelect.jsx
+++ b/src/components/vote/voteComponents/RegionSelect.jsx
@@ -14,12 +14,12 @@ const REGIONS = {
 const RegionSelect = ({ onRegionSelect }) => {
   return (
     <div className="flex w-full items-center justify-between">
-      <label htmlFor="region" className="text-sm whitespace-nowrap text-gray-700">
+      <label htmlFor="region" className="text-lg whitespace-nowrap text-gray-700">
         어느 지역에 계신가요?
       </label>
       <select
         id="region"
-        className="w-28 rounded-md border p-1 text-sm sm:w-32"
+        className="w-34 rounded-md border p-2 text-sm sm:w-34"
         defaultValue=""
         onChange={(e) => {
           const regionId = Number(e.target.value);

--- a/src/components/vote/voteComponents/VoteHeader.jsx
+++ b/src/components/vote/voteComponents/VoteHeader.jsx
@@ -2,13 +2,14 @@ import React from 'react';
 
 const VoteHeader = () => {
   return (
-    <div className="mx-auto mb-6 max-w-md px-4 text-center md:px-0">
-      <h1 className="mb-2 text-lg leading-snug font-bold md:text-2xl">
+    <div className="mb-6 w-full px-4 text-center overflow-hidden">
+      <h1 className="mb-2 text-2xl font-extrabold leading-snug md:text-5xl break-keep whitespace-nowrap">
         나는 누구의 공약에 공감할까?
       </h1>
-      <p className="text-xs leading-relaxed text-gray-600 md:text-sm">
-        후보들의 주요 공약을 비교해보고, <br />
-        지금 내가 공감하는 정책과 가까운 후보를 선택해 보세요.
+      <p className="text-sm leading-relaxed md:text-2xl">
+        후보들의 주요 공약을 비교해보고,
+        <br className="hidden md:inline" />
+        지금 내가 공감하는 정책과 가까운 후보를 선택해보세요.
       </p>
     </div>
   );


### PR DESCRIPTION
## 🔍 개요
Figma 디자인을 반영하여 Vote 페이지의 UI를 반응형으로 개선했습니다.
모바일과 데스크탑 환경 모두에서 요소들이 자연스럽게 보이도록 조정했습니다.

## ✅ 주요 변경 사항

<!-- 코드에서 핵심적으로 변경된 내용을 bullet 형식으로 정리해주세요. -->

- 후보 카드(CandidateCard) 레이아웃을 Figma 기준에 맞게 반응형 조정
- VoteHeader, Disclaimer 텍스트 스타일 및 줄바꿈 개선
- 모바일에서 폰트 크기 및 간격 축소, 데스크탑에서는 넉넉하게 확장
![image](https://github.com/user-attachments/assets/5a91495d-0330-441c-9722-ddb13c88fe09)
![image](https://github.com/user-attachments/assets/417e2fa3-4335-4c92-82cd-cbcfe29ef949)


