### PR TITLE
fix: 공약 총정리 - 드롭다운 열릴 때 스크롤바 깜빡이는 현상 해결

### DIFF
--- a/src/components/policySummary/policySummaryComponents/PolicyItem.jsx
+++ b/src/components/policySummary/policySummaryComponents/PolicyItem.jsx
@@ -32,19 +32,21 @@ const PolicyItem = ({ category, items }) => {
       </button>
 
       {isOpen && (
-        <div
-          className={`fade-in-up mt-6 border-t border-[#B7B7B7] pt-6 md:mt-8 md:pt-8 ${
-            visible ? 'show' : ''
-          }`}
-        >
-          <ul className="flex flex-col gap-1 px-3.5 md:text-lg">
-            {items.map((item, idx) => (
-              <li key={idx} className="flex gap-3 text-left md:gap-4">
-                <div className="bg-primary mt-2.5 h-1 w-1 shrink-0 rounded-full md:h-1.5 md:w-1.5" />
-                {item}
-              </li>
-            ))}
-          </ul>
+        <div className="fade-wrapper">
+          <div
+            className={`fade-in-up mt-6 border-t border-[#B7B7B7] pt-6 md:mt-8 md:pt-8 ${
+              visible ? 'show' : ''
+            }`}
+          >
+            <ul className="flex flex-col gap-1 px-3.5 md:text-lg">
+              {items.map((item, idx) => (
+                <li key={idx} className="flex gap-3 text-left md:gap-4">
+                  <div className="bg-primary mt-2.5 h-1 w-1 shrink-0 rounded-full md:h-1.5 md:w-1.5" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>{' '}
         </div>
       )}
     </div>

--- a/src/styles/policy.css
+++ b/src/styles/policy.css
@@ -61,14 +61,20 @@
   }
 }
 
-/* 등장 애니메이션: 스르륵 */
+/* 등장 애니메이션*/
+
+.fade-wrapper {
+  overflow: hidden;
+}
+
 .fade-in-up {
   opacity: 0;
-  transform: translateY(24px);
+  transform: translateY(16px);
   transition:
     opacity 0.9s cubic-bezier(0.25, 0.8, 0.25, 1),
     transform 0.9s cubic-bezier(0.25, 0.8, 0.25, 1);
   will-change: opacity, transform;
+  overflow-anchor: none;
 }
 
 .fade-in-up.show {


### PR DESCRIPTION
## 🔍 개요
드롭다운 항목이 등장할 때 translateY 애니메이션으로 인해 페이지 높이가 일시적으로 늘어나면서 스크롤바가 깜빡이는 문제가 발생했습니다. 

## ✅ 주요 변경 사항
- 애니메이션 요소를 fade-wrapper로 감싸고, overflow: hidden을 적용하여 스크롤 생성 방지했습니다. 
-  translateY 값을 24px → 16px로 조정하여 부드러운 효과를 유지하면서도 레이아웃 변화 최소화했습니다. 

