### PR TITLE
Feat: 구주와 후보 사퇴로 인한 지지율 그래프 삭제

### DIFF
--- a/src/components/approvalRating/RatingCharts.jsx
+++ b/src/components/approvalRating/RatingCharts.jsx
@@ -27,7 +27,7 @@ const RatingCharts = () => {
 
   const renderBarItems = () =>
     ratings
-      .filter((candidate) => candidate.name !== '기타')
+      .filter((candidate) => candidate.name !== '기타' && candidate.name !== '구주와')
       .map((candidate) => (
         <BarItem key={candidate.id} {...candidate} color={`--color-${candidate.partyKey}`} />
       ));


### PR DESCRIPTION
## 🔍 개요

구주와 후보 사퇴

## ✅ 주요 변경 사항

- 실시간 지지율 섹션에서 구주와 후보 그래프 제거
