### PR TITLE
fix: 라이트 모드일때 toast ui 검정 바탕으로 안나오는 오류 해결

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -105,7 +105,7 @@ option,
   }
 }
 
-/* 토스트 */
+/* 토스트 공통 스타일 */
 .toast-responsive {
   font-size: 14px;
   padding: 12px 16px;
@@ -113,8 +113,6 @@ option,
   width: 100%;
   border-radius: 8px;
   backdrop-filter: blur(4px);
-  background-color: rgba(0, 0, 0, 0.7);
-  color: #fff;
   z-index: 9999;
   position: relative;
 }
@@ -127,15 +125,14 @@ option,
   }
 }
 
-/* 다크 모드 대응 */
+/* 라이트 모드 강제 스타일 */
+html:not(.dark) .toast-responsive {
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #fff;
+}
+
+/* 다크 모드 */
 html.dark .toast-responsive {
   background-color: rgba(255, 255, 255, 0.7);
   color: #000;
 }
-
-/* @media (prefers-color-scheme: dark) {
-  .toast-responsive {
-    background-color: rgba(255, 255, 255, 0.85);
-    color: #000;
-  }
-} */


### PR DESCRIPTION
## 🔍 개요

병합하기 전에는 라이트 모드일때 toast ui 배경이 검정으로 잘보이는데 병합 후 흰색으로 보이는 오류..해결..

## ✅ 주요 변경 사항

- index.css 수정
