### PR TITLE
fix: 커서 좌표 설정으로 클릭 위치 어긋남 수정

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -76,7 +76,9 @@ html::-webkit-scrollbar {
 
 /*커서 변경*/
 body {
-  cursor: url('/src/assets/cursor.svg'), auto;
+  cursor:
+    url('/src/assets/cursor.svg') 18 18,
+    auto;
 }
 
 button,
@@ -84,7 +86,9 @@ a,
 select,
 option,
 [class*='cursor-pointer'] {
-  cursor: url('/src/assets/cursor.svg'), auto !important;
+  cursor:
+    url('/src/assets/cursor.svg') 18 18,
+    auto !important;
 }
 
 @media (max-width: 768px) {
@@ -93,7 +97,9 @@ option,
   }
 
   body {
-    cursor: url('/src/assets/cursor-m.png'), auto;
+    cursor:
+      url('/src/assets/cursor-m.png') 12 12,
+      auto;
   }
 
   button,
@@ -101,7 +107,9 @@ option,
   select,
   option,
   [class*='cursor-pointer'] {
-    cursor: url('/src/assets/cursor-m.png'), auto !important;
+    cursor:
+      url('/src/assets/cursor-m.png') 12 12,
+      auto !important;
   }
 }
 


### PR DESCRIPTION
## 🔍 개요

데스크탑(36px)과 모바일(24px) 커서 이미지의 기준점이 
좌측 상단(0,0)으로 지정되어 있어 클릭 위치와 실제 커서 포인터가 어긋나는 문제가 발생했습니다.


## ✅ 주요 변경 사항

- 각 이미지 중심 좌표 (데스크탑: 18 18, 모바일: 12 12)로  hotspot 위치를 조정하여
커서 이미지가 실제 클릭 지점과 자연스럽게 일치하도록 수정했습니다!
